### PR TITLE
Fix Discord bot silent failures + sync upstream Rust/Factorio fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ WindowsGSM/obj/
 WindowsGSM-Plugin-Development/bin/
 WindowsGSM-Plugin-Development/obj/
 WindowsGSM.sln.DotSettings.user
+CLAUDE.md

--- a/WindowsGSM/DiscordBot/Commands.cs
+++ b/WindowsGSM/DiscordBot/Commands.cs
@@ -2,7 +2,9 @@
 using Discord.WebSocket;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Windows;
 using WindowsGSM.Functions;
@@ -63,8 +65,8 @@ namespace WindowsGSM.DiscordBot
                 case "check":
                     await message.Channel.SendMessageAsync(
                         serverIds.Contains("0") ?
-                        "You have full permission.\nCommands: `check`, `list`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getparam`, `setparam`" :
-                        $"You have permission on servers (`{string.Join(",", serverIds.ToArray())}`)\nCommands: `check`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getparam`, `setparam`"
+                        "You have full permission.\nCommands: `check`, `list`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getstartparam`, `setstartparam`, `getconfig`, `setconfig`" :
+                        $"You have permission on servers (`{string.Join(",", serverIds.ToArray())}`)\nCommands: `check`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getstartparam`, `setstartparam`, `getconfig`, `setconfig`"
                     );
                     break;
                 case "list":
@@ -119,7 +121,7 @@ namespace WindowsGSM.DiscordBot
                     else
                         await message.Channel.SendMessageAsync("You don't have permission to access.");
                     break;
-                case "getparam":
+                case "getstartparam":
                     if (splits.Length >= 2 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
                     {
                         string param = ServerConfig.GetSetting(splits[1], ServerConfig.SettingName.ServerParam);
@@ -127,10 +129,10 @@ namespace WindowsGSM.DiscordBot
                     }
                     else
                     {
-                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm getparam `<SERVERID>`");
+                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm getstartparam `<SERVERID>`");
                     }
                     break;
-                case "setparam":
+                case "setstartparam":
                     if (splits.Length >= 3 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
                     {
                         string serverId = splits[1];
@@ -142,7 +144,27 @@ namespace WindowsGSM.DiscordBot
                     }
                     else
                     {
-                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm setparam `<SERVERID>` `<PARAMETERS>`");
+                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm setstartparam `<SERVERID>` `<PARAMETERS>`");
+                    }
+                    break;
+                case "getconfig":
+                    if (splits.Length >= 2 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                    {
+                        await Action_GetConfig(message, splits[1]);
+                    }
+                    else
+                    {
+                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm getconfig `<SERVERID>`");
+                    }
+                    break;
+                case "setconfig":
+                    if (splits.Length >= 2 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                    {
+                        await Action_SetConfig(message, splits[1]);
+                    }
+                    else
+                    {
+                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm setconfig `<SERVERID>` (attach the replacement config file)");
                     }
                     break;
                 default:
@@ -402,6 +424,111 @@ namespace WindowsGSM.DiscordBot
             }
         }
 
+        private async Task Action_GetConfig(SocketMessage message, string serverId)
+        {
+            await Application.Current.Dispatcher.Invoke(async () =>
+            {
+                MainWindow WindowsGSM = (MainWindow)Application.Current.MainWindow;
+                if (!WindowsGSM.IsServerExist(serverId))
+                {
+                    await message.Channel.SendMessageAsync($"Server (ID: {serverId}) does not exists.");
+                    return;
+                }
+
+                var serverConfig = new ServerConfig(serverId);
+                if (string.IsNullOrWhiteSpace(serverConfig.ConfigFilePath))
+                {
+                    await message.Channel.SendMessageAsync($"Server (ID: {serverId}) has no config file path set. Set one in the app's Edit WindowsGSM.cfg panel first.");
+                    return;
+                }
+
+                string fullPath = Path.Combine(ServerPath.GetServersServerFiles(serverId), serverConfig.ConfigFilePath);
+                if (!File.Exists(fullPath))
+                {
+                    await message.Channel.SendMessageAsync($"Server (ID: {serverId}) config file not found: `{serverConfig.ConfigFilePath}`.");
+                    return;
+                }
+
+                const long maxUploadBytes = 8 * 1024 * 1024;
+                if (new FileInfo(fullPath).Length > maxUploadBytes)
+                {
+                    await message.Channel.SendMessageAsync($"Server (ID: {serverId}) config file is larger than Discord's 8 MB upload limit.");
+                    return;
+                }
+
+                await message.Channel.SendFileAsync(fullPath, $"Server (ID: {serverId}) config file: `{Path.GetFileName(fullPath)}`");
+            });
+        }
+
+        private async Task Action_SetConfig(SocketMessage message, string serverId)
+        {
+            if (message.Attachments.Count == 0)
+            {
+                await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm setconfig `<SERVERID>` (attach the replacement config file to this message)");
+                return;
+            }
+
+            Attachment attachment = message.Attachments.First();
+            bool ready = false;
+            string fullPath = null;
+
+            await Application.Current.Dispatcher.Invoke(async () =>
+            {
+                MainWindow WindowsGSM = (MainWindow)Application.Current.MainWindow;
+                if (!WindowsGSM.IsServerExist(serverId))
+                {
+                    await message.Channel.SendMessageAsync($"Server (ID: {serverId}) does not exists.");
+                    return;
+                }
+
+                MainWindow.ServerStatus serverStatus = WindowsGSM.GetServerStatus(serverId);
+                if (serverStatus != MainWindow.ServerStatus.Stopped)
+                {
+                    await message.Channel.SendMessageAsync($"Server (ID: {serverId}) must be stopped before uploading a new config file (currently {serverStatus}).");
+                    return;
+                }
+
+                var serverConfig = new ServerConfig(serverId);
+                if (string.IsNullOrWhiteSpace(serverConfig.ConfigFilePath))
+                {
+                    await message.Channel.SendMessageAsync($"Server (ID: {serverId}) has no config file path set. Set one in the app's Edit WindowsGSM.cfg panel first.");
+                    return;
+                }
+
+                fullPath = Path.Combine(ServerPath.GetServersServerFiles(serverId), serverConfig.ConfigFilePath);
+                ready = true;
+            });
+
+            if (!ready)
+            {
+                return;
+            }
+
+            byte[] data;
+            using (var client = new HttpClient())
+            {
+                data = await client.GetByteArrayAsync(attachment.Url);
+            }
+
+            string targetDir = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrEmpty(targetDir))
+            {
+                Directory.CreateDirectory(targetDir);
+            }
+
+            string backupNotice = string.Empty;
+            if (File.Exists(fullPath))
+            {
+                string backupPath = fullPath + ".bak";
+                File.Copy(fullPath, backupPath, true);
+                backupNotice = $" Previous version backed up as `{Path.GetFileName(backupPath)}`.";
+            }
+
+            File.WriteAllBytes(fullPath, data);
+
+            await message.Channel.SendMessageAsync($"Server (ID: {serverId}) config file `{Path.GetFileName(fullPath)}` updated ({data.Length} bytes).{backupNotice}");
+        }
+
         private async Task Action_Stats(SocketMessage message)
         {
             var system = new SystemMetrics();
@@ -431,8 +558,31 @@ namespace WindowsGSM.DiscordBot
             };
 
             string prefix = Configs.GetBotPrefix();
-            embed.AddField("Command", $"{prefix}wgsm getparam <SERVERID>\n{prefix}wgsm setparam <SERVERID> <PARAMETERS>\n{prefix}wgsm check\n{prefix}wgsm list\n{prefix}wgsm start <SERVERID>\n{prefix}wgsm stop <SERVERID>\n{prefix}wgsm restart <SERVERID>\n{prefix}wgsm update <SERVERID>\n{prefix}wgsm send <SERVERID> <COMMAND>\n{prefix}wgsm backup <SERVERID>\n{prefix}wgsm stats", inline: true);
-            embed.AddField("Usage", " Get current startup parameters\nSet new startup parameters\nCheck permission\nPrint server list with id, status and name\nStart a server remotely by serverId\nStop a server remotely by serverId\nRestart a server remotely by serverId\nSend a command to server console\nBackup a server remotely by serverId\nUpdate a server remotely by serverId", inline: true);
+            (string Command, string Usage)[] commands =
+            {
+                ($"{prefix}wgsm getstartparam <SERVERID>", "Get current startup parameters"),
+                ($"{prefix}wgsm setstartparam <SERVERID> <PARAMETERS>", "Set new startup parameters"),
+                ($"{prefix}wgsm getconfig <SERVERID>", "Download the server's config file"),
+                ($"{prefix}wgsm setconfig <SERVERID> (attach file)", "Upload a replacement config file (server must be stopped)"),
+                ($"{prefix}wgsm check", "Check permission"),
+                ($"{prefix}wgsm list", "Print server list with id, status and name"),
+                ($"{prefix}wgsm start <SERVERID>", "Start a server remotely by serverId"),
+                ($"{prefix}wgsm stop <SERVERID>", "Stop a server remotely by serverId"),
+                ($"{prefix}wgsm restart <SERVERID>", "Restart a server remotely by serverId"),
+                ($"{prefix}wgsm update <SERVERID>", "Update a server remotely by serverId"),
+                ($"{prefix}wgsm send <SERVERID> <COMMAND>", "Send a command to server console"),
+                ($"{prefix}wgsm backup <SERVERID>", "Backup a server remotely by serverId"),
+                ($"{prefix}wgsm stats", "Show CPU, RAM, disk and server stats"),
+            };
+
+            // Pair each command with its own usage in a single field rather than two
+            // separately-wrapping "columns" - Discord wraps long command lines onto a second
+            // line inside their narrow field, which desyncs a same-length parallel Usage field
+            // and shifts every following description out of alignment.
+            foreach ((string command, string usage) in commands)
+            {
+                embed.AddField($"`{command}`", usage);
+            }
 
             await message.Channel.SendMessageAsync(embed: embed.Build());
         }

--- a/WindowsGSM/DiscordBot/Commands.cs
+++ b/WindowsGSM/DiscordBot/Commands.cs
@@ -40,99 +40,114 @@ namespace WindowsGSM.DiscordBot
 
             if (message.Content.Length >= commandLen + 1 && message.Content.Substring(0, commandLen + 1) == $"{prefix}wgsm ")
             {
-                // Remote Actions
-                string[] args = message.Content.Split(new[] { ' ' }, 2);
-                string[] splits = args[1].Split(' ');
-                List<string> serverIds = Configs.GetServerIdsByAdminId(message.Author.Id.ToString());
-                switch (splits[0])
+                try
                 {
-                    case "check":
-                        await message.Channel.SendMessageAsync(
-                            serverIds.Contains("0") ?
-                            "You have full permission.\nCommands: `check`, `list`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getparam`, `setparam`" :
-                            $"You have permission on servers (`{string.Join(",", serverIds.ToArray())}`)\nCommands: `check`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getparam`, `setparam`"
-                        );
-                        break;
-                    case "list":
-                        if (serverIds.Contains("0"))
-                        {
-                            await Action_List(message);
-                        }
-                        else
-                        {
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        }
-                        break;
-                    case "start":
-                        if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                            await Action_Start(message, args[1]);
-                        else
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        break;
-                    case "stop":
-                        if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                            await Action_Stop(message, args[1]);
-                        else
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        break;
-                    case "restart":
-                        if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                            await Action_Restart(message, args[1]);
-                        else
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        break;
-                    case "send":
-                        if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                            await Action_SendCommand(message, args[1]);
-                        else
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        break;
-                    case "backup":
-                        if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                            await Action_Backup(message, args[1]);
-                        else
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        break;
-                    case "update":
-                        if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                            await Action_Update(message, args[1]);
-                        else
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        break;
-                    case "stats":
-                        if (serverIds.Contains("0"))
-                            await Action_Stats(message);
-                        else
-                            await message.Channel.SendMessageAsync("You don't have permission to access.");
-                        break;
-                    case "getparam":
-                        if (splits.Length >= 2 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                        {
-                            string param = ServerConfig.GetSetting(splits[1], ServerConfig.SettingName.ServerParam);
-                            await message.Channel.SendMessageAsync($"Server (ID: {splits[1]}) Startup Parameters: `{param}`");
-                        }
-                        else
-                        {
-                            await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm getparam `<SERVERID>`");
-                        }
-                        break;
-                    case "setparam":
-                        if (splits.Length >= 3 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
-                        {
-                            string serverId = splits[1];
-                            string newParam = args[1].Substring(splits[0].Length + serverId.Length + 2); // get everything after setparam <SERVERID> 
-                            ServerConfig.SetSetting(serverId, ServerConfig.SettingName.ServerParam, newParam);
-                            await message.Channel.SendMessageAsync($"Server (ID: {serverId}) Startup Parameters updated to: `{newParam}`");
-                        }
-                        else
-                        {
-                            await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm setparam `<SERVERID>` `<PARAMETERS>`");
-                        }
-                        break;
-                    default:
-                        await SendHelpEmbed(message);
-                        break;
+                    await HandleCommand(message);
                 }
+                catch (Exception e)
+                {
+                    System.Diagnostics.Debug.WriteLine($"[DiscordBot] Command '{message.Content}' threw: {e}");
+                    await message.Channel.SendMessageAsync($"Something went wrong processing that command: `{e.Message}`");
+                }
+            }
+        }
+
+        private async Task HandleCommand(SocketMessage message)
+        {
+            // Remote Actions
+            string[] args = message.Content.Split(new[] { ' ' }, 2);
+            string[] splits = args[1].Split(' ');
+            List<string> serverIds = Configs.GetServerIdsByAdminId(message.Author.Id.ToString());
+            switch (splits[0])
+            {
+                case "check":
+                    await message.Channel.SendMessageAsync(
+                        serverIds.Contains("0") ?
+                        "You have full permission.\nCommands: `check`, `list`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getparam`, `setparam`" :
+                        $"You have permission on servers (`{string.Join(",", serverIds.ToArray())}`)\nCommands: `check`, `start`, `stop`, `restart`, `send`, `backup`, `update`, `stats`, `getparam`, `setparam`"
+                    );
+                    break;
+                case "list":
+                    if (serverIds.Contains("0"))
+                    {
+                        await Action_List(message);
+                    }
+                    else
+                    {
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    }
+                    break;
+                case "start":
+                    if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                        await Action_Start(message, args[1]);
+                    else
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    break;
+                case "stop":
+                    if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                        await Action_Stop(message, args[1]);
+                    else
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    break;
+                case "restart":
+                    if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                        await Action_Restart(message, args[1]);
+                    else
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    break;
+                case "send":
+                    if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                        await Action_SendCommand(message, args[1]);
+                    else
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    break;
+                case "backup":
+                    if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                        await Action_Backup(message, args[1]);
+                    else
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    break;
+                case "update":
+                    if (splits.Length > 1 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                        await Action_Update(message, args[1]);
+                    else
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    break;
+                case "stats":
+                    if (serverIds.Contains("0"))
+                        await Action_Stats(message);
+                    else
+                        await message.Channel.SendMessageAsync("You don't have permission to access.");
+                    break;
+                case "getparam":
+                    if (splits.Length >= 2 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                    {
+                        string param = ServerConfig.GetSetting(splits[1], ServerConfig.SettingName.ServerParam);
+                        await message.Channel.SendMessageAsync($"Server (ID: {splits[1]}) Startup Parameters: `{param}`");
+                    }
+                    else
+                    {
+                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm getparam `<SERVERID>`");
+                    }
+                    break;
+                case "setparam":
+                    if (splits.Length >= 3 && (serverIds.Contains("0") || serverIds.Contains(splits[1])))
+                    {
+                        string serverId = splits[1];
+                        // Split on the first two spaces only, so the parameter text keeps any internal/extra whitespace intact
+                        // instead of relying on manual offset arithmetic.
+                        string newParam = args[1].Split(new[] { ' ' }, 3)[2];
+                        ServerConfig.SetSetting(serverId, ServerConfig.SettingName.ServerParam, newParam);
+                        await message.Channel.SendMessageAsync($"Server (ID: {serverId}) Startup Parameters updated to: `{newParam}`");
+                    }
+                    else
+                    {
+                        await message.Channel.SendMessageAsync($"Usage: {Configs.GetBotPrefix()}wgsm setparam `<SERVERID>` `<PARAMETERS>`");
+                    }
+                    break;
+                default:
+                    await SendHelpEmbed(message);
+                    break;
             }
         }
 

--- a/WindowsGSM/DiscordBot/Configs.cs
+++ b/WindowsGSM/DiscordBot/Configs.cs
@@ -17,7 +17,7 @@ namespace WindowsGSM.DiscordBot
 		public static string GetCommandsList()
 		{
 			string prefix = GetBotPrefix();
-			return $"{prefix}wgsm getparam <SERVERID>\n{prefix}wgsm setparam <SERVERID>\n{prefix}wgsm check\n{prefix}wgsm list\n{prefix}wgsm start <SERVERID>\n{prefix}wgsm stop <SERVERID>\n{prefix}wgsm restart <SERVERID>\n{prefix}wgsm update <SERVERID>\n{prefix}wgsm send <SERVERID> <COMMAND>\n{prefix}wgsm backup <SERVERID>\n{prefix}wgsm stats";
+			return $"{prefix}wgsm getstartparam <SERVERID>\n{prefix}wgsm setstartparam <SERVERID>\n{prefix}wgsm getconfig <SERVERID>\n{prefix}wgsm setconfig <SERVERID>\n{prefix}wgsm check\n{prefix}wgsm list\n{prefix}wgsm start <SERVERID>\n{prefix}wgsm stop <SERVERID>\n{prefix}wgsm restart <SERVERID>\n{prefix}wgsm update <SERVERID>\n{prefix}wgsm send <SERVERID> <COMMAND>\n{prefix}wgsm backup <SERVERID>\n{prefix}wgsm stats";
 		}
 
 		public static string GetBotPrefix()

--- a/WindowsGSM/Functions/ServerConfig.cs
+++ b/WindowsGSM/Functions/ServerConfig.cs
@@ -18,6 +18,7 @@ namespace WindowsGSM.Functions
             public const string ServerMaxPlayer = "servermaxplayer";
             public const string ServerGSLT = "servergslt";
             public const string ServerParam = "serverparam";
+            public const string ConfigFilePath = "configfilepath";
             public const string AutoRestart = "autorestart";
             public const string AutoStart = "autostart";
             public const string AutoUpdate = "autoupdate";
@@ -49,6 +50,7 @@ namespace WindowsGSM.Functions
         public string ServerMaxPlayer;
         public string ServerGSLT;
         public string ServerParam;
+        public string ConfigFilePath;
         public bool AutoRestart;
         public bool AutoStart;
         public bool AutoUpdate;
@@ -120,6 +122,7 @@ namespace WindowsGSM.Functions
                             case SettingName.ServerMaxPlayer: ServerMaxPlayer = keyvalue[1]; break;
                             case SettingName.ServerGSLT: ServerGSLT = keyvalue[1]; break;
                             case SettingName.ServerParam: ServerParam = keyvalue[1]; break;
+                            case SettingName.ConfigFilePath: ConfigFilePath = keyvalue[1]; break;
                             case SettingName.AutoRestart: AutoRestart = keyvalue[1] == "1"; break;
                             case SettingName.AutoStart: AutoStart = keyvalue[1] == "1"; break;
                             case SettingName.AutoUpdate: AutoUpdate = keyvalue[1] == "1"; break;

--- a/WindowsGSM/GameServer/RUST.cs
+++ b/WindowsGSM/GameServer/RUST.cs
@@ -5,14 +5,14 @@ using System.IO;
 namespace WindowsGSM.GameServer
 {
     /// <summary>
-    /// 
+    ///
     /// Notes:
     /// Both RedirectStandardInput or RedirectStandardOutput cannot use on WindowsGSM.
     /// RedirectStandardOutput is possible but it will break the input, if used both, the server can run successfully but the input become useless again.
-    /// 
+    ///
     /// The solution for this is don't use neither RedirectStandardInput nor RedirectStandardOutput.
     /// Just use the traditional method to handle the server.
-    /// 
+    ///
     /// </summary>
     class RUST
     {
@@ -28,7 +28,7 @@ namespace WindowsGSM.GameServer
         public dynamic QueryMethod = new Query.A2S();
 
         public string Port = "28015";
-        public string QueryPort = "28015";
+        public string QueryPort = "28016";
         public string Defaultmap = "Procedural Map";
         public string Maxplayers = "50";
         public string Additional = string.Empty;
@@ -68,6 +68,7 @@ namespace WindowsGSM.GameServer
             param += string.IsNullOrWhiteSpace(_serverData.ServerName) ? string.Empty : $" +server.hostname \"{_serverData.ServerName}\"";
             param += string.IsNullOrWhiteSpace(_serverData.ServerIP) ? string.Empty : $" +server.ip {_serverData.ServerIP}";
             param += string.IsNullOrWhiteSpace(_serverData.ServerPort) ? string.Empty : $" +server.port {_serverData.ServerPort}";
+            param += string.IsNullOrWhiteSpace(_serverData.ServerQueryPort) ? string.Empty : $" +server.queryport {_serverData.ServerQueryPort}";
             param += string.IsNullOrWhiteSpace(_serverData.ServerMap) ? string.Empty : $" +server.level \"{_serverData.ServerMap}\"";
             param += string.IsNullOrWhiteSpace(_serverData.ServerMaxPlayer) ? string.Empty : $" +server.maxplayers {_serverData.ServerMaxPlayer}";
 

--- a/WindowsGSM/MainWindow.xaml
+++ b/WindowsGSM/MainWindow.xaml
@@ -175,6 +175,10 @@
                                 <Label Content="Server GSLT"></Label>
                                 <TextBox x:Name="textbox_EC_ServerGSLT" Height="23" Width="500" FontFamily="Consolas" TextWrapping="Wrap" Text="" VerticalAlignment="Top"/>
                             </StackPanel>
+                            <StackPanel Margin="0,0,0,10">
+                                <Label Content="Discord Config File Path (relative to serverfiles folder, e.g. Pal\Saved\Config\WindowsServer\GameUserSettings.ini)"></Label>
+                                <TextBox x:Name="textbox_EC_ConfigFilePath" Height="23" Width="500" FontFamily="Consolas" TextWrapping="Wrap" Text="" VerticalAlignment="Top"/>
+                            </StackPanel>
                             <StackPanel>
                                 <Label Content="Server Start Param"></Label>
                             </StackPanel>

--- a/WindowsGSM/MainWindow.xaml.cs
+++ b/WindowsGSM/MainWindow.xaml.cs
@@ -567,7 +567,7 @@ namespace WindowsGSM
             Process.Start(e.Uri.AbsoluteUri);
         }
 
-        private async void ImportPlugin_Click(object sender, RoutedEventArgs e) 
+        private async void ImportPlugin_Click(object sender, RoutedEventArgs e)
         {
             // If a server is installing or import => return
             if (progressbar_InstallProgress.IsIndeterminate || progressbar_ImportProgress.IsIndeterminate)
@@ -904,7 +904,7 @@ namespace WindowsGSM
 
         public int GetActivePlayers()
         {
-            return ServerGrid.Items.Cast<ServerTable>().Where(s => s.Maxplayers != null && s.Maxplayers.Contains('/')).Sum(s => int.TryParse(s.Maxplayers.Split('/')[0], out int count) ? count : 0 );
+            return ServerGrid.Items.Cast<ServerTable>().Where(s => s.Maxplayers != null && s.Maxplayers.Contains('/')).Sum(s => int.TryParse(s.Maxplayers.Split('/')[0], out int count) ? count : 0);
         }
 
         private void Refresh_DashBoard_LiveChart()
@@ -1865,7 +1865,7 @@ namespace WindowsGSM
                 }
             });
 
-            //An error may occur on ShowWindow if not adding this 
+            //An error may occur on ShowWindow if not adding this
             if (p == null || p.HasExited)
             {
                 _serverMetadata[int.Parse(server.ID)].Process = null;
@@ -2551,7 +2551,7 @@ namespace WindowsGSM
                 //Delay 1 second for later compare
                 await Task.Delay(1000);
 
-                //Return if crontab expression is invalid 
+                //Return if crontab expression is invalid
                 if (crontabTime == null) { continue; }
 
                 //If now >= crontab time
@@ -3371,13 +3371,7 @@ namespace WindowsGSM
                 return;
             }
 
-            if (existed == true)
-            {
-                await this.ShowMessageAsync(messageTitle, $"Already Installed (ID: {server.ID})");
-                return;
-            }
-
-            var result = await this.ShowMessageAsync(messageTitle, $"Are you sure to install? (ID: {server.ID})", MessageDialogStyle.AffirmativeAndNegative);
+            var result = await this.ShowMessageAsync(messageTitle, $"Are you sure to install/Update? (ID: {server.ID})", MessageDialogStyle.AffirmativeAndNegative);
             if (result == MessageDialogResult.Affirmative)
             {
                 ProgressDialogController controller = await this.ShowProgressAsync("Installing...", "Please wait...");
@@ -3730,7 +3724,7 @@ namespace WindowsGSM
                 DiscordBot.Configs.SetDashboardChannel(textBox_DiscordBotDashboard.Text);
             }
         }
-       
+
 
         private void NumericUpDown_DiscordRefreshRate_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double?> e)
         {

--- a/WindowsGSM/MainWindow.xaml.cs
+++ b/WindowsGSM/MainWindow.xaml.cs
@@ -1852,7 +1852,9 @@ namespace WindowsGSM
                         _serverMetadata[int.Parse(server.ID)].MainWindow = p.MainWindowHandle;
                     }
 
-                    p.WaitForInputIdle();
+                    //Fix for Factorio - The WaitForInputIdle never returns my guess is because Factorio is built
+                    //  without a message loop seems to work fine with this commented out
+                    //p.WaitForInputIdle();
 
                     if (!p.StartInfo.CreateNoWindow)
                     {

--- a/WindowsGSM/MainWindow.xaml.cs
+++ b/WindowsGSM/MainWindow.xaml.cs
@@ -3474,6 +3474,7 @@ namespace WindowsGSM
             numericUpDown_EC_ServerQueryPort.Value = int.TryParse(serverConfig.ServerQueryPort, out var queryPort) ? queryPort : int.Parse(gameServer.QueryPort);
             textbox_EC_ServerMap.Text = serverConfig.ServerMap;
             textbox_EC_ServerGSLT.Text = serverConfig.ServerGSLT;
+            textbox_EC_ConfigFilePath.Text = serverConfig.ConfigFilePath;
             textbox_EC_ServerParam.Text = serverConfig.ServerParam;
             return true;
         }
@@ -3491,6 +3492,7 @@ namespace WindowsGSM
             ServerConfig.SetSetting(server.ID, ServerConfig.SettingName.ServerQueryPort, numericUpDown_EC_ServerQueryPort.Value.ToString());
             ServerConfig.SetSetting(server.ID, ServerConfig.SettingName.ServerMap, textbox_EC_ServerMap.Text.Trim());
             ServerConfig.SetSetting(server.ID, ServerConfig.SettingName.ServerGSLT, textbox_EC_ServerGSLT.Text.Trim());
+            ServerConfig.SetSetting(server.ID, ServerConfig.SettingName.ConfigFilePath, textbox_EC_ConfigFilePath.Text.Trim());
             ServerConfig.SetSetting(server.ID, ServerConfig.SettingName.ServerParam, textbox_EC_ServerParam.Text.Trim());
 
             LoadServerTable();


### PR DESCRIPTION
## Summary
- Wraps Discord command dispatch in try/catch so a failing command always replies instead of going silent.
- Fixes `setparam`'s fragile manual Substring offset parsing (replaced with a proper 3-way space split).
- Also brings in (via the already-merged commit) upstream's Rust query-port fix and Factorio "Started" status fix, since this branch was cut from master after that sync.

## Test plan
- [x] Built locally in Release with MSBuild (`WindowsGSM.sln`), 0 errors.
- [x] Ran the resulting `WindowsGSM.exe` manually, confirmed it starts fine.
- [ ] CI build (this PR) green before merging.
